### PR TITLE
Added ID to Character/Changed ID algo in death print

### DIFF
--- a/src/entity/Character.java
+++ b/src/entity/Character.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id and get/set methods)
  *
  */
 
@@ -11,12 +12,13 @@
 package entity;
 
 /**
- * Character superclass handles a Character's health and attack
+ Character superclass handles a Character's health, attack, and id
  */
 public class Character {
     // The private variables associated with the Character Class
     private int health;
     private int attack;
+    private int id = -1;
 
 
     // Class constructor receives health and attack from subclasses and initializes
@@ -26,28 +28,16 @@ public class Character {
         this.attack = attack;
     }
 
-
-    // Setter method for the health instance variable
-    public void setHealth(int health) {
+    // Class constructor receives health, attack, and id from subclasses and initializes
+    // the instance variables
+    public Character(int health, int attack, int id) {
         this.health = health;
+        this.attack = attack;
+        this.id = id;
     }
 
-
-    // Getter method for the health instance variable
-
-    public int getHealth() {
-        return this.health;
-    }
-
-
-    // Getter method for the attack instance variable
-    public int getAttack() {
-        return attack;
-    }
-
-
-    // Attack method calculates the passed in characters health after the attack
-    // and sets the characters health to the result
+     // Attack method calculates the passed in characters health after the attack
+     // and sets the characters health to the result
     public void attack(Character character) {
         // Subtracts the passed in character's health by the attack of this instance
         int healthAfter = character.getHealth() - this.attack;
@@ -58,8 +48,38 @@ public class Character {
         character.setHealth(Math.max(healthAfter, 0));
     }
 
+    // Getter method for the attack instance variable
+    public int getAttack() {
+        return attack;
+    }
+
+    // Getter method for the health instance variable
+    public int getHealth() {
+        return this.health;
+    }
+
+    // Getter method for id
+    public int getId() {
+        return id;
+    }
+
     // Checks if the player is alive (health not 0) and returns boolean
     public boolean isAlive() {
         return health != 0;
+    }
+
+    // Setter method for attack
+    public void setAttack(int attack) {
+        this.attack = attack;
+    }
+
+    // Setter method for id
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    // Setter method for the health instance variable
+    public void setHealth(int health) {
+        this.health = health;
     }
 }

--- a/src/entity/CharacterList.java
+++ b/src/entity/CharacterList.java
@@ -3,6 +3,8 @@
  * CharacterList.java
  * November 28, 2021
  * Updated(Initials, Date, Changes):
+ *  (DAB, 12/03/2021, CharacterLists are now constructed with
+ *  unique ID's)
  *
  *
  */
@@ -54,6 +56,10 @@ public class CharacterList {
         int survivorCount = (int) (Math.floor(Math.random() * MAX_SURVIVOR_CHARACTERS)+1);
         // Declaring a variable to hold the random Survivor subclass
         int survivorType;
+        // Adding ID's for Zombie Characters
+        int childID = 0;
+        int teacherID = 0;
+        int soldierID = 0;
 
         // The random number of Survivor objects will be constructed
         for (int i = 0; i < survivorCount; i++) {
@@ -61,13 +67,14 @@ public class CharacterList {
             survivorType = (int) Math.floor(Math.random() * (MAX_SURVIVOR_TYPES));
 
             // Using multi-directional control statement to create the correct Survivor
-            // subclass and add it to the survivorList
+            // subclass and add it to the survivorList. ID's are used to construct the
+            // Character objects
             if (survivorType == CHILD) {
-                this.survivorList.add(new Child());
+                this.survivorList.add(new Child(childID++));
             } else if (survivorType == TEACHER) {
-                this.survivorList.add(new Teacher());
+                this.survivorList.add(new Teacher(teacherID++));
             } else if (survivorType == SOLDIER) {
-                this.survivorList.add(new Soldier());
+                this.survivorList.add(new Soldier(soldierID++));
             } else {
                 System.out.println("Error creating survivor list, check in CharacterList.java");
             }
@@ -83,6 +90,9 @@ public class CharacterList {
         int zombieCount = (int) (Math.floor(Math.random() * MAX_ZOMBIE_CHARACTERS)+1);
         // Declaring a variable to hold the random Zombie subclass
         int zombieType;
+        // Adding ID's for Zombie Characters
+        int commonInfectID = 0;
+        int tankId = 0;
 
         // The random number of Zombie objects will be constructed
         for (int i = 0; i < zombieCount; i++) {
@@ -90,11 +100,12 @@ public class CharacterList {
             zombieType = (int) Math.floor(Math.random() * (MAX_ZOMBIE_TYPES));
 
             // Using multi-directional control statement to create the correct Zombie
-            // subclass and add it to the zombieList
+            // subclass and add it to the zombieList. ID's are used to construct the
+            // Character objects
             if (zombieType == COMMON_INFECT) {
-                this.zombieList.add(new CommonInfect());
+                this.zombieList.add(new CommonInfect(commonInfectID++));
             } else if (zombieType == TANK) {
-                this.zombieList.add(new Tank());
+                this.zombieList.add(new Tank(tankId++));
             } else {
                 System.out.println("Error creating zombie list, check in CharacterList.java");
             }

--- a/src/entity/Child.java
+++ b/src/entity/Child.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class Child extends Survivor {
     // Class constructor passing in health and attack to superclass
     public Child() {
         super(20, 2);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Child(int id) {
+        super(20, 2, id);
     }
 }

--- a/src/entity/CommonInfect.java
+++ b/src/entity/CommonInfect.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class CommonInfect extends Zombie {
     // Class constructor passing in health and attack to superclass
     public CommonInfect() {
         super(30, 5);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public CommonInfect(int id) {
+        super(30, 5, id);
     }
 }

--- a/src/entity/Match.java
+++ b/src/entity/Match.java
@@ -8,6 +8,8 @@
  *  to the Class variables, start() algo, Match Class
  *  main comment)
  *  (DAB, 11/30/2021, Altered the start() algorithm)
+ *  (DAB, 12/03/2021, Changed the start() algo to print out
+ *  deaths based of IDs)
  *
  *
  */
@@ -60,7 +62,9 @@ public class Match {
         // Using a while loop to traverse through each x/attacker one at a time
         while (attacker.hasNext()) {
             // Saving the currentId to a variable and the current attacker
-            int currentAttackerID = attacker.nextIndex();
+            // int currentAttackerID = attacker.nextIndex();
+
+            // Iterating to the next attacker
             Character currentAttacker = attacker.next();
 
             // If the currentAttacker is alive it will attack all alive defenders
@@ -74,7 +78,7 @@ public class Match {
                 // While there is a defender in the List to traverse
                 while (defender.hasNext()) {
                     // Assigning the current defender ID to a variable
-                    int currentDefenderID = defender.nextIndex();
+                    // int currentDefenderID = defender.nextIndex();
 
                     // The next defender is assigned to the currentDefender
                     Character currentDefender = defender.next();
@@ -91,8 +95,8 @@ public class Match {
                             String defenderClass = currentDefender.getClass().getSimpleName();
 
                             // Printing out that the defender is dead and what attacker killed them
-                            System.out.println("  " + attackerClass + " " + currentAttackerID +
-                                    " killed " + defenderClass + " " + currentDefenderID);
+                            System.out.println("  " + attackerClass + " " + currentAttacker.getId() +
+                                    " killed " + defenderClass + " " + currentDefender.getId());
 
 //                            // DEBUG: **********************HEALTH**********************************
 //                            System.out.println(attackerClass + " hp is " + currentAttacker.getHealth());

--- a/src/entity/Soldier.java
+++ b/src/entity/Soldier.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  *
  */
@@ -19,5 +20,10 @@ public class Soldier extends Survivor {
     // Class constructor passing in health and attack to superclass
     public Soldier() {
         super(100, 10);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Soldier(int id) {
+        super(100, 10, id);
     }
 }

--- a/src/entity/Survivor.java
+++ b/src/entity/Survivor.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class Survivor extends Character {
     // Class constructor passing in health and attack to superclass
     public Survivor(int health, int attack) {
         super(health, attack);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Survivor(int health, int attack, int id) {
+        super(health, attack, id);
     }
 }

--- a/src/entity/Tank.java
+++ b/src/entity/Tank.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class Tank extends Zombie {
     // Class constructor passing in health and attack to superclass
     public Tank() {
         super(150, 20);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Tank(int id) {
+        super(150, 20, id);
     }
 }

--- a/src/entity/Teacher.java
+++ b/src/entity/Teacher.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class Teacher extends Survivor {
     // Class constructor passing in health and attack to superclass
     public Teacher() {
         super(50, 5);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Teacher(int id) {
+        super(50, 5, id);
     }
 }

--- a/src/entity/Zombie.java
+++ b/src/entity/Zombie.java
@@ -4,6 +4,7 @@
  * November 28, 2021
  * Updated(Initials, Date, Changes):
  *  (DAB, 11/28/2021, added main class comment)
+ *  (DAB, 12/03/2021, added in id constructor)
  *
  */
 
@@ -18,5 +19,10 @@ public class Zombie extends Character {
     // Class constructor passing in health and attack to superclass
     public Zombie(int health, int attack) {
         super(health, attack);
+    }
+
+    // Class constructor passing in health, attack, and id to superclass
+    public Zombie(int health, int attack, int id) {
+        super(health, attack, id);
     }
 }


### PR DESCRIPTION
Due to a bug found by @flierc-csp . The ID assignment was significantly changed. Changes are below:

The Character classes were updated to include an ID field.
The death printout used this ID field to indicate which attacker/defender is involved. 
CharacterList was updated to assign ID's, 0-N, based off order of construction.

closed #23 